### PR TITLE
SOAP Implementation of REST BulkUploadController

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,30 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.jvnet.jaxb2.maven2</groupId>
+				<artifactId>maven-jaxb2-plugin</artifactId>
+				<version>0.14.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<schemaDirectory>${project.basedir}/src/main/resources/xsd</schemaDirectory>
+					<generateDirectory>${project.basedir}/src/main/java</generateDirectory>
+					<schemas>
+						<schema>
+							<files>
+								<file>bulk-upload.xsd</file>
+							</files>
+						</schema>
+					</schemas>
+					<packageName>com.theta.ThetaVideoApiBulkUpload.soap.gen</packageName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<repositories>

--- a/src/main/java/com/theta/ThetaVideoApiBulkUpload/soap/BulkUploadSoapEndpoint.java
+++ b/src/main/java/com/theta/ThetaVideoApiBulkUpload/soap/BulkUploadSoapEndpoint.java
@@ -1,0 +1,67 @@
+package com.theta.ThetaVideoApiBulkUpload.soap;
+
+import com.theta.ThetaVideoApiBulkUpload.Service.ThetaVideoService;
+import com.theta.ThetaVideoApiBulkUpload.apiModels.ProcessedVideoResponse;
+import com.theta.ThetaVideoApiBulkUpload.soap.gen.BulkUploadRequest;
+import com.theta.ThetaVideoApiBulkUpload.soap.gen.BulkUploadResponse;
+import org.springframework.ws.server.endpoint.annotation.Endpoint;
+import org.springframework.ws.server.endpoint.annotation.PayloadRoot;
+import org.springframework.ws.server.endpoint.annotation.RequestPayload;
+import org.springframework.ws.server.endpoint.annotation.ResponsePayload;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+@Endpoint
+public class BulkUploadSoapEndpoint {
+
+    private static final String NAMESPACE_URI = "http://theta.com/bulkupload";
+
+    private final ThetaVideoService thetaVideoService;
+
+    public BulkUploadSoapEndpoint(ThetaVideoService thetaVideoService) {
+        this.thetaVideoService = thetaVideoService;
+    }
+
+    @PayloadRoot(namespace = NAMESPACE_URI, localPart = "BulkUploadRequest")
+    @ResponsePayload
+    public BulkUploadResponse handleBulkUpload(@RequestPayload BulkUploadRequest request)
+            throws IOException, InterruptedException, ExecutionException {
+
+        // Convert uploaded files (already base64-encoded byte[])
+        List<byte[]> listOfFilesBytes = request.getFiles()
+                .stream()
+                .map(f -> f)
+                .collect(Collectors.toList());
+
+        ProcessedVideoResponse processedVideoResponse;
+
+        if (request.isAsyncFlow()) {
+            thetaVideoService.processBulkUploadAsync(
+                    listOfFilesBytes,
+                    request.getThetaApiKey(),
+                    request.getThetaApiSecret(),
+                    request.getWebhookUrl()
+            );
+            processedVideoResponse = new ProcessedVideoResponse();
+            processedVideoResponse.setStatus("success");
+            processedVideoResponse.setMessage("Operation In Progress, You will get the final response on your webhook");
+        } else {
+            var checkVideoUploadResponses = thetaVideoService.processBulkUpload(
+                    listOfFilesBytes,
+                    request.getThetaApiKey(),
+                    request.getThetaApiSecret()
+            );
+            processedVideoResponse = thetaVideoService.compileProcessedVideoResponse(checkVideoUploadResponses);
+        }
+
+        // Map to SOAP response
+        BulkUploadResponse response = new BulkUploadResponse();
+        response.setStatus(processedVideoResponse.getStatus());
+        response.setMessage(processedVideoResponse.getMessage());
+
+        return response;
+    }
+}

--- a/src/main/resources/xsd/bulk-upload.xsd
+++ b/src/main/resources/xsd/bulk-upload.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://theta.com/bulkupload"
+           xmlns="http://theta.com/bulkupload"
+           elementFormDefault="qualified">
+
+    <xs:element name="BulkUploadRequest">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="files" type="xs:base64Binary" maxOccurs="unbounded"/>
+                <xs:element name="thetaApiKey" type="xs:string"/>
+                <xs:element name="thetaApiSecret" type="xs:string"/>
+                <xs:element name="asyncFlow" type="xs:boolean"/>
+                <xs:element name="webhookUrl" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="BulkUploadResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="status" type="xs:string"/>
+                <xs:element name="message" type="xs:string"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
This PR introduces a SOAP implementation of the Bulk Upload service alongside the existing REST controller. A new bulk-upload.xsd schema defines request/response contracts for file uploads, API credentials, and webhook handling. Implemented BulkUploadSoapEndpoint reuses existing ThetaVideoService logic for both async and sync flows.